### PR TITLE
Add payload as a parameter for key_provider function

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -64,7 +64,7 @@ class JWT implements HttpKernelInterface
                 );
             }
 
-            if (!$jws->isValid($this->options['key_provider']())) {
+            if (!$jws->isValid($this->options['key_provider']($jws->getPayload()))) {
                 return $challenge(
                     new Response('Invalid JSON Web Token', 401),
                     'invalid_token'


### PR DESCRIPTION
If `key_provider` function gets the payload as a parameter it can return with a user specific secret.
